### PR TITLE
Restructure `catch_and_log_fit()`

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -108,24 +108,39 @@ catch_and_log <- function(.expr, ..., bad_only = FALSE, notes) {
 catch_and_log_fit <- function(expr, ..., notes) {
   tune_log(..., type = "info")
 
-  result <- catcher(expr)
-  fit <- tryCatch(
-    result$res$fit$fit$fit,
-    error = function(c) as.character(result$res)
-  )
+  caught <- catcher(expr)
+  result <- caught$res
 
-  # Log underlying fit failures that parsnip caught and exit
+  # Log failures that come from parsnip before the model is fit
+  if (is_failure(result)) {
+    result_parsnip <- list(res = result, signals = list())
+
+    new_notes <- log_problems(notes, ..., result_parsnip)
+    assign(".notes", new_notes, envir = parent.frame())
+    return(result)
+  }
+
+  if (!is_workflow(result)) {
+    abort("Internal error: Model result is not a workflow!")
+  }
+
+  # Extract the parsnip model from the fitted workflow
+  fit <- result$fit$fit$fit
+
+  # Log underlying fit failures that parsnip caught during the actual
+  # fitting process
   if (is_failure(fit)) {
     result_fit <- list(res = fit, signals = list())
 
     new_notes <- log_problems(notes, ..., result_fit)
     assign(".notes", new_notes, envir = parent.frame())
-    return(result$res)
+    return(result)
   }
 
-  new_notes <- log_problems(notes, ..., result)
+  new_notes <- log_problems(notes, ..., caught)
   assign(".notes", new_notes, envir = parent.frame())
-  result$res
+
+  result
 }
 
 log_best <- function(control, iter, info, digits = 4) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,3 +5,7 @@ is_recipe <- function(x) {
 is_preprocessor <- function(x) {
   is_recipe(x) || rlang::is_formula(x)
 }
+
+is_workflow <- function(x) {
+  inherits(x, "workflow")
+}


### PR DESCRIPTION
This specifically catches when parsnip throws the error before the model is actually fit.

We expect that the `$result` is a workflow object, but it could be an error object if something went wrong inside parsnip, but before the model is actually fit. This specifically checks for that case, and then also has an extra validation check that the `$result` really is a workflow object before continuing on to extract the fit. At that point,  the structure should be correct so the underlying fit _should_ always be there.

Note: Lionel and I have been marking these validation checks with `Internal error:` as an indicator that they are important, but the user should never see them. At some point in the future they might get their own error class